### PR TITLE
fix: handle BOM prefix in package.json

### DIFF
--- a/index.js
+++ b/index.js
@@ -19,7 +19,7 @@ module.exports = function nmTree (basePath, tree) {
   const packageJsonPath = path.join(basePath, 'package.json')
   const nodeModulesPath = path.join(basePath, 'node_modules')
   if (fs.existsSync(packageJsonPath)) {
-    const packageJson = JSON.parse(fs.readFileSync(packageJsonPath))
+    const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, 'utf8').trim())
     tree[basePath] = packageJson
     if (fs.existsSync(nodeModulesPath)) { // TODO: and is dir
       const nodeModulesPackages = fs.readdirSync(nodeModulesPath)


### PR DESCRIPTION
Hi there.

Caught an exception while parsing `paralleljs` package.json. It contains BOM prefix, so it just needs to be removed.
Similar issue: https://github.com/bazelbuild/rules_nodejs/issues/1448

```
Unexpected token ﻿ in JSON at position 0
```